### PR TITLE
Respect max field and record length in ISO2709 serializer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 target/
+build/
+.gradle/
+.idea/

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>se.kb.libris</groupId>
     <artifactId>marc</artifactId>
     <packaging>jar</packaging>
-    <version>1.3.2</version>
+    <version>1.3.4</version>
     <name>LIBRIS MARC Tools</name>
     <organization>
         <name>LIBRIS</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>se.kb.libris</groupId>
     <artifactId>marc</artifactId>
     <packaging>jar</packaging>
-    <version>1.3.4</version>
+    <version>1.3.3</version>
     <name>LIBRIS MARC Tools</name>
     <organization>
         <name>LIBRIS</name>

--- a/src/main/java/se/kb/libris/util/marc/io/Iso2709Serializer.java
+++ b/src/main/java/se/kb/libris/util/marc/io/Iso2709Serializer.java
@@ -9,12 +9,15 @@ package se.kb.libris.util.marc.io;
 import java.io.*;
 import java.util.*;
 import se.kb.libris.util.marc.*;
+import se.kb.libris.util.marc.impl.MarcRecordImpl;
 
 /**
  *
  * @author  Martin Malmsten
  */
 public class Iso2709Serializer {
+    private static final int MAX_FIELD_LEN = 9999;
+    private static final int MAX_RECORD_LEN = 99999;
     public static boolean debug = false;
     
     public static byte[] serialize(MarcRecord record) {
@@ -27,7 +30,7 @@ public class Iso2709Serializer {
         while (iter.hasNext()) {
             Field f = (Field)iter.next();
             nFields++;
-            byte tmp[] = null;
+            byte[] tmp;
             
             System.arraycopy(f.getTag().getBytes(), 0, directory, 12*(nFields-1), 3);
             
@@ -35,33 +38,20 @@ public class Iso2709Serializer {
                 Controlfield cf = (Controlfield)f;
                 tmp = cf.getData().getBytes();
             } else {
-                StringBuffer sb = new StringBuffer();
-                Datafield df = (Datafield)f;
-
-                sb.append(df.getIndicator(0));
-                sb.append(df.getIndicator(1));
-
-                Iterator sfiter = df.iterator();
-                while (sfiter.hasNext()) {
-                    Subfield sf = (Subfield)sfiter.next();
-
-                    sb.append((char)MarcRecord.SUBFIELD_MARK);
-                    sb.append(sf.getCode());
-                    sb.append(sf.getData());
-                }
-
-                //System.out.println(sb);
-                
-                tmp = sb.toString().getBytes();
+                tmp = serialize((Datafield) f);
             }
             
             fields.add(tmp);
-            recSize += tmp.length;            
+            recSize += tmp.length;
         }
                 
         // size is: leader(24) + directory(12*nFields) + END_OF_FIELD(1) + fields(nFields*(length+1)) + END_OF_RECORD(1)
+        int size = 24 + 12*nFields + 1 + recSize + nFields + 1;
+        if (size > MAX_RECORD_LEN) {
+            return (serialize(dropLongestField(record)));
+        }
         
-        byte rec[] = new byte[24 + 12*nFields + 1 + recSize + nFields + 1];
+        byte[] rec = new byte[size];
 
         System.arraycopy(leader, 0, rec, 0, leader.length);
         System.arraycopy(directory, 0, rec, leader.length, directory.length);
@@ -108,7 +98,7 @@ public class Iso2709Serializer {
         
         return rec;
     }
-
+    
     public static byte[] serialize(MarcRecord record, String encoding) throws UnsupportedEncodingException {
         Vector fields = new Vector();
         byte directory[] = new byte[12*record.getFields().size()], leader[] = record.getLeader().getBytes("ISO8859-1");
@@ -119,7 +109,7 @@ public class Iso2709Serializer {
         while (iter.hasNext()) {
             Field f = (Field)iter.next();
             nFields++;
-            byte tmp[] = null;
+            byte[] tmp;
             
             System.arraycopy(f.getTag().getBytes("ISO8859-1"), 0, directory, 12*(nFields-1), 3);
 
@@ -127,33 +117,20 @@ public class Iso2709Serializer {
                 Controlfield cf = (Controlfield)f;
                 tmp = cf.getData().getBytes(encoding);
             } else {
-                StringBuffer sb = new StringBuffer();
-                Datafield df = (Datafield)f;
-
-                sb.append(df.getIndicator(0));
-                sb.append(df.getIndicator(1));
-
-                Iterator sfiter = df.iterator();
-                while (sfiter.hasNext()) {
-                    Subfield sf = (Subfield)sfiter.next();
-
-                    sb.append((char)MarcRecord.SUBFIELD_MARK);
-                    sb.append(sf.getCode());
-                    sb.append(sf.getData());
-                }
-
-                //System.out.println(sb);
-                
-                tmp = sb.toString().getBytes(encoding);
+                tmp = serialize((Datafield) f, encoding);
             }
             
             fields.add(tmp);
-            recSize += tmp.length;            
+            recSize += tmp.length;
         }
                 
         // size is: leader(24) + directory(12*nFields) + END_OF_FIELD(1) + fields(nFields*(length+1)) + END_OF_RECORD(1)
-        
-        byte rec[] = new byte[24 + 12*nFields + 1 + recSize + nFields + 1];
+        int size = 24 + 12*nFields + 1 + recSize + nFields + 1;
+        if (size > MAX_RECORD_LEN) {
+            return (serialize(dropLongestField(record)));
+        }
+
+        byte[] rec = new byte[size];
 
         System.arraycopy(leader, 0, rec, 0, leader.length);
         System.arraycopy(directory, 0, rec, leader.length, directory.length);
@@ -208,5 +185,96 @@ public class Iso2709Serializer {
         rec[rec.length - 1] = MarcRecord.END_OF_RECORD;        
         
         return rec;
+    }
+    
+    private static byte[] serialize(Datafield df) {
+        try {
+            return serialize(df, null);
+        } catch (UnsupportedEncodingException cannotHappen) {
+            // Never throws unless passed an encoding
+            throw new RuntimeException(cannotHappen);
+        }
+    }
+    
+    private static byte[] serialize(Datafield df, String encoding) throws UnsupportedEncodingException {
+        StringBuilder sb = new StringBuilder();
+
+        sb.append(df.getIndicator(0));
+        sb.append(df.getIndicator(1));
+
+        Iterator<Subfield> sfiter = df.iterator();
+        while (sfiter.hasNext()) {
+            Subfield sf = sfiter.next();
+
+            sb.append((char)MarcRecord.SUBFIELD_MARK);
+            sb.append(sf.getCode());
+            sb.append(sf.getData());
+        }
+        
+        byte[] bytes = str2bytes(sb.toString(), encoding);
+
+        if (bytes.length > MAX_FIELD_LEN) {
+            // (Recursively) cut data of the longest subfield to fit within maximum field length  
+            Subfield longest = findLongestSubfield(df);
+
+            String data = longest.getData();
+            byte[] b = str2bytes(data, encoding);
+            int newLen = Math.max(0, b.length - (bytes.length - MAX_FIELD_LEN + 1));
+            longest.setData(bytes2str(Arrays.copyOf(b, newLen), encoding));
+            bytes = serialize(df, encoding);
+            longest.setData(data);
+        }
+
+        return bytes;
+    }
+    
+    private static byte[] str2bytes(String s, String encoding) throws UnsupportedEncodingException {
+        return encoding != null ? s.getBytes(encoding) : s.getBytes();
+    }
+
+    private static String bytes2str(byte[] b, String encoding) throws UnsupportedEncodingException {
+        return encoding != null ? new String(b, encoding) : new String(b);
+    }
+    
+    private static Subfield findLongestSubfield(Datafield df) {
+        int maxLen = -1;
+        Subfield longest = null;
+        Iterator<Subfield> sfiter = df.iterator();
+        while (sfiter.hasNext()) {
+            Subfield sf = sfiter.next();
+            if (sf.getData() != null && sf.getData().length() > maxLen) {
+                maxLen = sf.getData().length();
+                longest = sf;
+            }
+        }
+        return longest;
+    }
+
+    private static MarcRecord dropLongestField(MarcRecord record) {
+        MarcRecordImpl copy = new MarcRecordImpl();
+        copy.setLeader(record.getLeader());
+
+        Iterator<Field> i = record.iterator();
+        int maxLen = -1;
+        Datafield longest = null;
+        while (i.hasNext()) {
+            Field f = i.next();
+            if (f instanceof Datafield) {
+                int len = serialize((Datafield) f).length;
+                if (len > maxLen) {
+                    maxLen = len;
+                    longest = (Datafield) f;
+                }
+            } 
+        }
+
+        i = record.iterator();
+        while (i.hasNext()) {
+            Field f = i.next();
+            if (f != longest) {
+                copy.addField(f);
+            }
+        }
+        return copy;
     }
 }


### PR DESCRIPTION
Don't output invalid ISO2709 for long fields/records.

A field can never contain more than 9999 bytes in total since
the length is encoded as four decimal digits.

A record can never contain more than 99999 bytes in total since
the length is encoded as five decimal digits.

bib 520 (summary) with length > 9999 bytes have been observed in the
wild.

Fix:
- cut the data of the longest subfield until they fit inside the field.
- drop the longest field until they fit inside the record.

"Record length (character positions 00-04), contains a five-character
ASCII numeric string equal to the length of the entire record, including
itself and the record terminator. The five-character numeric string is
right justified and unused positions contain zeroes (zero fill). The
maximum length of a record is 99999 octets."

"Length of field (character positions 03-06), contains four ASCII
numeric characters which give the length, expressed as a decimal number,
of the variable field to which the entry corresponds. This length
includes the indicators, subfield codes, data and field terminator
associated with the field. A field length number of fewer than four
digits is right justified and unused positions contain zeroes (zero
fill). MARC 21 sets the length of the length of field portion of the
entry at four characters, thus a field may contain a maximum of 9999
octets."

https://www.loc.gov/marc/specifications/specrecstruc.html